### PR TITLE
Fix issue with filtering of `.gitignore` entries with a trailing separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.2.0
+
+### 🐞 Bug Fixes
+
+- Fix issue with filtering of `.gitignore` entries with a trailing separator.
+
 ## v0.1.0
 
 ### 🚀 Features

--- a/src/libs/fs.ts
+++ b/src/libs/fs.ts
@@ -89,7 +89,11 @@ async function getGitignoreExcludeGlobs(workspaceFolder: WorkspaceFolder) {
         continue
       }
 
-      excludeGlobs.push(gitignoreEntry.startsWith(path.posix.sep) ? gitignoreEntry.slice(1) : `**/${gitignoreEntry}`)
+      let excludeGlob = gitignoreEntry.startsWith(path.posix.sep) ? gitignoreEntry.slice(1) : `**/${gitignoreEntry}`
+      // If there is a separator at the end of the pattern then the pattern should match directories.
+      excludeGlob = excludeGlob.endsWith(path.posix.sep) ? `${excludeGlob}**` : excludeGlob
+
+      excludeGlobs.push(excludeGlob)
     }
   } catch {
     // We can safely ignore this error if the file doesn't exist or is not readable.

--- a/src/tests/multi-root/extension.test.ts
+++ b/src/tests/multi-root/extension.test.ts
@@ -45,6 +45,7 @@ describe('with a multi-root workspace', () => {
                 '/folder-2/folder-2-2',
                 '/folder-2/folder-2-2/folder-2-2-1',
                 '/folder-2/folder-2-2/folder-2-2-2',
+                '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
                 '/folder-2/folder-2-2/random',
               ])
             ).to.be.true
@@ -68,6 +69,7 @@ describe('with a multi-root workspace', () => {
                 '/folder-2/folder-2-2',
                 '/folder-2/folder-2-2/folder-2-2-1',
                 '/folder-2/folder-2-2/folder-2-2-2',
+                '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
                 '/folder-2/folder-2-2/random',
               ])
             ).to.be.true
@@ -90,6 +92,7 @@ describe('with a multi-root workspace', () => {
                 '/folder-2/folder-2-2',
                 '/folder-2/folder-2-2/folder-2-2-1',
                 '/folder-2/folder-2-2/folder-2-2-2',
+                '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
                 '/folder-2/folder-2-2/random',
               ])
             ).to.be.true
@@ -393,6 +396,7 @@ describe('with a multi-root workspace', () => {
               '/folder-2/folder-2-2',
               '/folder-2/folder-2-2/folder-2-2-1',
               '/folder-2/folder-2-2/folder-2-2-2',
+              '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
               '/folder-2/folder-2-2/random',
             ])
           ).to.be.true

--- a/src/tests/single-folder/extension.test.ts
+++ b/src/tests/single-folder/extension.test.ts
@@ -43,6 +43,7 @@ describe('with a single-folder workspace', () => {
                 '/folder-2/folder-2-2',
                 '/folder-2/folder-2-2/folder-2-2-1',
                 '/folder-2/folder-2-2/folder-2-2-2',
+                '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
                 '/folder-2/folder-2-2/random',
                 '/folder-3',
               ])
@@ -69,6 +70,7 @@ describe('with a single-folder workspace', () => {
                 '/folder-2/folder-2-2',
                 '/folder-2/folder-2-2/folder-2-2-1',
                 '/folder-2/folder-2-2/folder-2-2-2',
+                '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
                 '/folder-2/folder-2-2/random',
                 '/folder-3',
               ])
@@ -94,6 +96,7 @@ describe('with a single-folder workspace', () => {
                 '/folder-2/folder-2-2',
                 '/folder-2/folder-2-2/folder-2-2-1',
                 '/folder-2/folder-2-2/folder-2-2-2',
+                '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
                 '/folder-2/folder-2-2/random',
                 '/folder-3',
               ])
@@ -111,7 +114,7 @@ describe('with a single-folder workspace', () => {
           # a comment
           .file-3-1
           random
-          /folder-2/folder-2-2/folder-2-2-2
+          /folder-2/folder-2-2/folder-2-2-2/
         `
           )
         })
@@ -423,6 +426,7 @@ describe('with a single-folder workspace', () => {
               '/folder-2/folder-2-2',
               '/folder-2/folder-2-2/folder-2-2-1',
               '/folder-2/folder-2-2/folder-2-2-2',
+              '/folder-2/folder-2-2/folder-2-2-2/folder-2-2-2-1',
               '/folder-2/folder-2-2/random',
               '/folder-3',
             ])


### PR DESCRIPTION
This PR closes #3.

The issue was related to the process transforming `.gitignore` entries to globs. As specified in [the `.gitignore` pattern format](https://git-scm.com/docs/gitignore#_pattern_format), if there is a separator at the end of the pattern then the pattern will only match directories, meaning we should add `**` at the end of the pattern when transforming it to a glob pattern.